### PR TITLE
Update info about comments and docstrings.

### DIFF
--- a/content/generic.rst
+++ b/content/generic.rst
@@ -204,10 +204,10 @@ Comments
 
 * Avoid end of line comments.
 
-* Technical dept comments (ex FIXME, TODO) will always have an attached
+* Technical debt comments (ex FIXME, TODO) will always have an attached
   ticket ID and will use the following format. Only **FIXME** marker is used
   followed by ticket ID. Comments will come on a new lines.
-  Adapt this to the style of comments use in the specific language, but
+  Adapt this to the style of comments used in the specific language, but
   is important to keep the **FIXME:123:** marker.::
 
     # FIXME:1234:

--- a/content/generic.rst
+++ b/content/generic.rst
@@ -93,15 +93,6 @@ something is wrong.
 
 * Each repository will have a LICENSE and AUTHORS files.
 
-* Technical dept comments (ex FIXME, TODO) will always have an attached
-  ticket ID and will use the following format. Only **FIXME** marker is used
-  followed by ticket ID. Comments will come on a new lines.
-  Adapt this to the style of comments use in the specific language, but
-  is important to keep the **FIXME:123:** marker.::
-
-    # FIXME:1234:
-    # Details about this tech-dept. Ex: Can only be fixed when full moon.
-
 * Words are an important part of how software works.
   Even though there may be dozens of people creating a product, reading
   comments, documentation, notes etc, it should still sound like we speak
@@ -197,15 +188,53 @@ Comments
   for this thing, so here is my poor comment. Good luck with figuring the
   intend of this name when you see the it in the rest of this file.
 
-* Well commented code is extremely important. Take time to describe
-  components, how they work, their limitations, and the way they are
-  constructed. Don't leave others in the team guessing as to the purpose
-  of uncommon or non-obvious code.
+* Place comments on a new line above their subject and in the same block as the referred code.
 
-* Place comments on a new line above their subject.
+.. sourcecode:: python
 
-* Avoid end of line comments. End of line comments can be used for lint
-  ignores and other hints for automated tools... but not for humans.
+    if some_condition:
+      # We got into into this branch to do x.
+      do_domething()
+
+    for line in lines:
+      if line.startswith('marker'):
+        # Marker lines are ignored.
+        continue
+      do_domething()
+
+* Avoid end of line comments.
+
+* Technical dept comments (ex FIXME, TODO) will always have an attached
+  ticket ID and will use the following format. Only **FIXME** marker is used
+  followed by ticket ID. Comments will come on a new lines.
+  Adapt this to the style of comments use in the specific language, but
+  is important to keep the **FIXME:123:** marker.::
+
+    # FIXME:1234:
+    # Details about this tech-dept. Ex: Can only be fixed when full moon.
+
+
+Documentation
+=============
+
+* Well documented code is extremely important.
+  Take time to describe components, how they work, their limitations, and the way they are constructed.
+  Don't leave others in the team guessing as to the purpose of uncommon or non-obvious code.
+
+* Document code as part of docstrings and not as comments.
+
+* Document packages, modules, classes, functions.
+
+* For narative documentation (non docstrins) use `semantic linefeeds <http://rhodesmill.org/brandon/2012/one-sentence-per-line/>`_.
+
+..  code-block:: text
+    :linenos:
+
+    Sometimes when editing a narrative documentation file, I wrap the lines semantically.
+    Instead of inserting a newline at 70 columns (or whatever),
+    or making paragraphs one long line,
+    I put in newlines at a point that seems logical to me.
+    Modern code-oriented text editor are very good at wrapping and arranging long lines.
 
 
 Exceptions handling

--- a/content/library.rst
+++ b/content/library.rst
@@ -14,9 +14,13 @@ good/clean code and many more. The list is in random order:
   <http://pragprog.com/the-pragmatic-programmer/>`_
   (ISBN: 0-201-61622-X) by Andrew Hunt and David Thomas, published in October, 1999.
 
-* `Clean Code\: A Handbook of Agile Software Craftsmanship
+* `Clean Code: A Handbook of Agile Software Craftsmanship
   <http://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882>`_
   (ISBN: 978-0132350884) by Robert C. Martin, published in August 11, 2008.
+
+* `xUnit Test Patterns Refactoring Test Code
+  <http://www.amazon.com/gp/product/0131495054>`_
+  (ISBN: 978-0131495050) by Gerard Meszaros, published in May 31, 2007.
 
 * `Don't Make Me Think: A Common Sense Approach to Web Usability, 2nd Edition
   <http://www.amazon.com/exec/obidos/ASIN/0321344758/>`_

--- a/content/python.rst
+++ b/content/python.rst
@@ -7,6 +7,13 @@ Python
 General
 =======
 
+* Start by reading
+  `The Zen of Python <https://www.python.org/dev/peps/pep-0020/>`_
+
+.. sourcecode:: python
+
+    import this
+
 * For python we have pocket-lint that checks for PEP8 and some other things.
 
 * `Python PEP 8 <http://www.python.org/dev/peps/pep-0008/>`_
@@ -16,7 +23,8 @@ General
 
 * As the second best, use Mixins to reuse code and avoid multiple inheritance.
 
-* Docstring always use multiline strings with double quotes.
+* Docstring always use multiline strings with double quotes and empty first
+  and last lines. There's no blank line either before or after the docstring.
 
 .. sourcecode:: python
 
@@ -24,14 +32,21 @@ General
         """
         Single line docstring.
         """
+        code_starts_here()
 
 
     class SomeClass(ParentClass):
         """
-        Quick explanation of the role of this class.
+        Quick explanation of the role of this class which is a bit long so we
+        wrap it.
 
         More details to follow in long paragraphs.
         """
+
+        def method_starts_here(self):
+          """
+          Something here.
+          """
 
 * Class members or instance members can be documented inline using the
   following syntax.

--- a/content/references.rst
+++ b/content/references.rst
@@ -45,7 +45,7 @@ CSS
 
 .. _Launchpad Style Guides: https://dev.launchpad.net/
 .. _PEP8: http://www.python.org/dev/peps/pep-0008
-.. _PEP8: http://www.python.org/dev/peps/pep-0257
+.. _PEP257: http://www.python.org/dev/peps/pep-0257
 .. _Agilo small commits: https://agilo.agilofortrac.com/wiki/agilo/dev/SmallCommits
 .. _Stoyan's CSS: http://www.phpied.com/css-coding-conventions/
 .. _Idiomatic CSS: https://github.com/necolas/idiomatic-css

--- a/content/references.rst
+++ b/content/references.rst
@@ -22,6 +22,9 @@ Python
 ======
 
 * `PEP8`_
+* `PEP257`_
+* `Idiomatic Python
+  <http://python.net/~goodger/projects/pycon/2007/idiomatic/presentation.html>`_
 
 
 JavaScript
@@ -42,6 +45,7 @@ CSS
 
 .. _Launchpad Style Guides: https://dev.launchpad.net/
 .. _PEP8: http://www.python.org/dev/peps/pep-0008
+.. _PEP8: http://www.python.org/dev/peps/pep-0257
 .. _Agilo small commits: https://agilo.agilofortrac.com/wiki/agilo/dev/SmallCommits
 .. _Stoyan's CSS: http://www.phpied.com/css-coding-conventions/
 .. _Idiomatic CSS: https://github.com/necolas/idiomatic-css


### PR DESCRIPTION
I wanted to update our info about comments and docstrings.
Later I discovered semantic new lines and I think they are great for our RST docs.
For docstrings we still split at 80 so that we can send code upstream.

Please take a look and let me know what you think.

reviewers:
* [x] @alibotean 
* [x] @dumol

branch was already published online http://styleguide.chevah.com/
Thanks!