### PR TITLE
[#3314] Fix typos and broken URL

### DIFF
--- a/content/review.rst
+++ b/content/review.rst
@@ -167,7 +167,7 @@ Merge your branch
 After the merge request and review was approved you need to merge your branch
 into master.
 
-After your review request was approved, you can send you branch got PQM
+After your review request was approved, you can send your branch to PQM
 for automatic testing and merging. Use the following command::
 
     paver pqm GITHUB_PULL_REQUEST_ID

--- a/content/review.rst
+++ b/content/review.rst
@@ -14,9 +14,7 @@ General
   regardless of who "caused" the error. Branch driver and reviews work
   together to achieve this goal.
 
-* The review process is a very efficient form of pair-programming ...
-  `and is not this kind of pair programming
-  <http://whenarewehavingcake.tumblr.com/post/23507389861>`_.
+* The review process is a very efficient form of pair-programming.
 
 * Branch driver is the person (or persons) requesting the review and
   responsible for implementing changes during review.

--- a/content/work.rst
+++ b/content/work.rst
@@ -178,7 +178,7 @@ You will write many code, emails, documents, text chats.
 The process of writing should encourage you to slow down,
 organize and clarify your thoughts before sharing them with someone else.
 
-When things get to complicated, don't hesitate to switch to voice chat.
+When things get too complicated, don't hesitate to switch to voice chat.
 After a voice chat don't forget to document what was discussed by updating
 a document, sending a follow up email, updating a ticket or
 creating new tickets with new up tasks.


### PR DESCRIPTION
Scope
=====

As part of reading and providing feedback to the wiki and styleguide this Pull Request fixes typos and broken links in the styleguide.

Changes
=======

- Removed the broken URL linked in the review page.
- Fixed two small typos in review page.
- Fixed one typo in work page.

How to try and test the changes
===============================

reviewers: @adiroiban 

- Check that there is no broken link in the first section (General) of review page.
- In "Merge your branch" section it should read "you can send your branch to PQM".
- In the "Communication" section of Work page it should read "too complicated" instead of "to complicated". 
