### PR TITLE
Add notes about release reviewers.

### DIFF
--- a/content/release.rst
+++ b/content/release.rst
@@ -20,6 +20,18 @@ Releasing a product usually consists of publishing the following:
 * Public announcement. Notification email or website news/blog article.
 
 
+Release Review Process
+======================
+
+As a means to allow (read determine) all team members that are involved in
+coding, testing and supporting the product to keep up with the changes -- they
+must be part of the reviewers of the release branch/PR.
+
+Since you can easily get by without acting on a release/news email, being part
+of the reviewers will require at least a confirmation that you've okayed the
+changes.
+
+
 Release Notes
 =============
 

--- a/content/release.rst
+++ b/content/release.rst
@@ -23,13 +23,15 @@ Releasing a product usually consists of publishing the following:
 Release Review Process
 ======================
 
-As a means to allow (read determine) all team members that are involved in
-coding, testing and supporting the product to keep up with the changes -- they
-must be part of the reviewers of the release branch/PR.
+As a means to allow all team members that are involved in
+coding, testing and supporting the product to keep up with the changes,
+they must be part of the reviewers of the release branch/PR.
 
-Since you can easily get by without acting on a release/news email, being part
-of the reviewers will require at least a confirmation that you've okayed the
-changes.
+Being part of the release review will help to ackwnoledge the changes and to
+confirm that you've okayed the changes.
+
+The release review request should also include the text used to announce the
+new release on the website.
 
 
 Release Notes

--- a/content/release.rst
+++ b/content/release.rst
@@ -27,7 +27,7 @@ As a means to allow all team members that are involved in
 coding, testing and supporting the product to keep up with the changes,
 they must be part of the reviewers of the release branch/PR.
 
-Being part of the release review will help to ackwnoledge the changes and to
+Being part of the release review will help to acknowledge the changes and to
 confirm that you've okayed the changes.
 
 The release review request should also include the text used to announce the


### PR DESCRIPTION
Scope
=====

I felt that the support team (for the moment @adiroiban and me) need to be up to date with all the changes in the product.

Since I was only skimming the news/release emails and not diving up in the details (reading the PR descriptions, glancing over the code changes) I've told @adiroiban  that it might be a good idea to make all support people part of the reviewers list when a new release PR is created.

If you feel the tone/wording/etc. is not ok or might not even be needed please share your thoughts.

reviewers @adiroiban @brunogola @lgheorghiu 