### PR TITLE
[#3505] Make a link more reader-friendly

### DIFF
--- a/content/review.rst
+++ b/content/review.rst
@@ -143,8 +143,8 @@ Review request message
 ----------------------
 
 When submitting a ticket for review, the review request should contain the
-following message as described in `PULL_REQUEST_TEMPLATE
-<https://github.com/chevah/styleguide/blob/master/.github/PULL_REQUEST_TEMPLATE>`_
+following message as described in `pull request template
+<https://github.com/chevah/styleguide/blob/master/.github/PULL_REQUEST_TEMPLATE>`_:
 
 * For GitHub review requests, **add the merge commit message as the pull
   request title**. The message should include the ticket ID number.


### PR DESCRIPTION
Scope
=====

See [​Review * Chevah Style Guide](http://styleguide.chevah.com/review.html). There is the sentence: "When submitting a ticket for review, the review request should contain the following message as described in PULL_REQUEST_TEMPLATE". This change replaces "PULL_REQUEST_TEMPLATE" with more reader-friendly text: "pull request template".

Changes
=======
"PULL_REQUEST_TEMPLATE" is replaced with "pull request template".

reviewers: @adiroiban 