### PR TITLE
Fixed box overlap.

### DIFF
--- a/layout/static/css/chevah.css
+++ b/layout/static/css/chevah.css
@@ -340,7 +340,8 @@ pre {
   margin-right: 5px;
   -webkit-box-shadow: 2px 2px 2px 0px #d4d4d4;
   -moz-box-shadow: 2px 2px 2px 0px #d4d4d4;
-  box-shadow: 2px 2px 2px 0px #d4d4d4; }
+  box-shadow: 2px 2px 2px 0px #d4d4d4; 
+  display: -webkit-box;}
 
 code {
   font-size: 1em;


### PR DESCRIPTION
Scope
=====

Fix the box overlap between the side menu and the main content in some pages.


Why we got into this (5 whys)
=============================

Because it looked bad. X 5


Changes
=======

Updated the css 'pre' tag attributes with  'display: -webkit-box' 


How to try and test the changes
===============================

reviewers: @robi-net

Checked under Firefox and Chrome, unfortunately no Internet Explorer or Safari under hand.