### PR TITLE
Add Mailchimp steps to Release page

### DIFF
--- a/content/release.rst
+++ b/content/release.rst
@@ -481,12 +481,12 @@ After the website is updated and News item published we send a newsletter:
 1. Go to Campaigns in Mailchimp.
 
 2. Select 'Replicate' in the drop down besides 'NEW: SFTPPlus Release Announcement'.
+If it is a security bugfix, use the SFTPPlus Security Advisories email list.
 
 3. Select the News Announcements email list.
 
 4. Update the email subject and email with the News text used to announce the
-new release.
+new release. You can use the copy that is in the News article for the email.
 
-5. Select Send.
-
-If it is a security bugfix, use the SFTPPlus Security Advisories email list.
+5. Select Send. Before sending the final email, you can preview first by going
+to 'Preview and Send' on the top menu and select 'Send a test email'.

--- a/content/release.rst
+++ b/content/release.rst
@@ -16,7 +16,7 @@ Releasing a product usually consists of publishing the following:
 
 * Binary or source archives.
 * Documentation, which includes Release Notes, Known Issues and Upgrade Steps.
-* Public announcement. Notification email or website news/blog article.
+* Public announcement. Website news/blog article and newsletter.
 
 Each version sent to a customer should have a unique version number
 and must be mentioned in the release notes.
@@ -475,3 +475,18 @@ The **master** branch should be kept in good shape so that we can release it at
 any time.
 Especially if a security bugfix is found, we will make a new release as soon
 as the bug is fixed.
+
+After the website is updated and News item published we send a newsletter:
+
+1. Go to Campaigns in Mailchimp.
+
+2. Select 'Replicate' in the drop down besides 'NEW: SFTPPlus Release Announcement'.
+
+3. Select the News Announcements email list.
+
+4. Update the email subject and email with the News text used to announce the
+new release.
+
+5. Select Send.
+
+If it is a security bugfix, use the SFTPPlus Security Advisories email list.


### PR DESCRIPTION
Scope
=====
Discussions at https://github.com/chevah/styleguide/issues/34

Changes
=======
Steps added end of the page since newsletter should be the last item done in a Release process.

How to try and test the changes
========================
reviewers: @adiroiban