### PR TITLE
[#3763] Add some points regarding review process

### DIFF
--- a/content/review.rst
+++ b/content/review.rst
@@ -57,8 +57,8 @@ General
   This will help a lot with the review. Land your changes with the ugly
   names and then do a follow-up branch for the renaming.
 
-* Feel free to submit as many merge request as you can. The size of
-  merge requests can be an issue, but not their number :).
+* Feel free to submit as many merge requests as you can. The size of
+  the merge requests can be an issue, but not their number :).
 
 * Some reasons for keeping the merge requests small:
 
@@ -97,8 +97,8 @@ For the person requesting a review
   reviewer will check for sure.
 
 * Before submitting a ticket for review, check that you have documented your
-  work accordingly, for example in the affected repository documentation, or
-  the styleguide.
+  work accordingly, for example in the affected repository documentation,
+  Trac's Wiki, or the Styleguide.
 
 
 * For Trac: A review request is created by adding the comment and then
@@ -262,15 +262,15 @@ Reviewer's check list - Any Role
 ---------------------------------
 
 
-* Is there a release notes entry for changes?
+* Is there a release notes entry for the changes?
 
-* Is there documentation for changes?
-
-* Does the documentation make sense?
+* Are the changes documented?
 
 * Are the new events documented?
 
 * Are the removed events documented?
+
+* Does the documentation make sense?
 
 
 Reviewer's check list - Developer

--- a/content/review.rst
+++ b/content/review.rst
@@ -317,6 +317,9 @@ applying changes to Trac tickets.
 Integration is mainly between GitHub Pull Requests and Trac tickets,
 following the workflow described in `review <{filename}/review.rst>`_.
 
+Please do not use or rely on the new GitHub PR review features as they have
+no API and are not integrated in Trac.
+
 The Pull Request title should start with **[#TRAC_TICKET_ID]** and
 each message on this Pull Request triggers a hook looking for special keywords.
 

--- a/content/review.rst
+++ b/content/review.rst
@@ -5,6 +5,9 @@ Review
 
 This page will discuss the code/changes review process as both the person
 who requests a review and a person who checks the review.
+Please note that the same review concepts/procedures apply to all platforms
+(Github, Trac, email, etc) and not only to code changes, but to any task
+you are working on.
 
 ..  contents::
 
@@ -69,7 +72,7 @@ General
 
 
 For the person requesting a review
-==============================
+==================================
 
 * Once a task/ticket is done, it should be submitted for review.
 
@@ -92,6 +95,10 @@ For the person requesting a review
 
 * Check the **Reviewer's check list** since those are the things that a
   reviewer will check for sure.
+
+* Before submitting a ticket for review, check that you have documented your
+  work accordingly, like in a wiki page, or if you pushed a PR, list
+  the affected repositories, etc.
 
 * For Trac: A review request is created by adding the comment and then
   setting the state to 'needs_review'.
@@ -166,7 +173,7 @@ following message as described in `pull request template
 
 
 Merge your branch
-------------------
+-----------------
 
 After the merge request and review was approved you need to merge your branch
 into master.
@@ -203,7 +210,7 @@ A merge commit should have a commit message, in the format::
 
 
 For the person reviewing the changes
-============================
+====================================
 
 * Aim for a code inspection rate of fewer than 300 – 500 LOC per hour. This
   does not apply to QA team members for which, reviewing changes is the main

--- a/content/review.rst
+++ b/content/review.rst
@@ -5,8 +5,8 @@ Review
 
 This page will discuss the code/changes review process as both the person
 who requests a review and a person who checks the review.
-The guidelines will apply to all platforms (Ticketing systems, Emails, etc)
-and to all tasks, not only to code.
+The review instructions are platform independent so they apply to tickets,
+emails, pull requests, and to all tasks, not only to code reviews.
 
 
 ..  contents::
@@ -276,7 +276,7 @@ Reviewer's check list - Any Role
 Reviewer's check list - Developer
 ---------------------------------
 
-* Do the **new** changes comply with latest styleguide ?
+* Do the **new** changes comply with latest styleguide?
 
 * Does the code have automated tests for all the new code?
 

--- a/content/review.rst
+++ b/content/review.rst
@@ -5,9 +5,9 @@ Review
 
 This page will discuss the code/changes review process as both the person
 who requests a review and a person who checks the review.
-Please note that the same review concepts/procedures apply to all platforms
-(Github, Trac, email, etc) and not only to code changes, but to any task
-you are working on.
+The guidelines will apply to all platforms (Ticketing systems, Emails, etc)
+and to all tasks, not only to code.
+
 
 ..  contents::
 
@@ -57,7 +57,7 @@ General
   This will help a lot with the review. Land your changes with the ugly
   names and then do a follow-up branch for the renaming.
 
-* Feel free to submit as many merge request as you can. The size of 
+* Feel free to submit as many merge request as you can. The size of
   merge requests can be an issue, but not their number :).
 
 * Some reasons for keeping the merge requests small:
@@ -90,15 +90,16 @@ For the person requesting a review
   It is very important to have a good review request message as it will
   help reviewers understand what you have done.
 
-* Check that all changes are covered by automated tests and if they aren't, make sure
-  that the review description contains information regarding why.
+* Check that all changes are covered by automated tests and if they aren't,
+  make sure that the review description contains information regarding why.
 
 * Check the **Reviewer's check list** since those are the things that a
   reviewer will check for sure.
 
 * Before submitting a ticket for review, check that you have documented your
-  work accordingly, like in a wiki page, or if you pushed a PR, list
-  the affected repositories, etc.
+  work accordingly, for example in the affected repository documentation, or
+  the styleguide.
+
 
 * For Trac: A review request is created by adding the comment and then
   setting the state to 'needs_review'.
@@ -263,7 +264,7 @@ Reviewer's check list - Any Role
 
 * Is there a release notes entry for changes?
 
-* Is there documentation for changes? 
+* Is there documentation for changes?
 
 * Does the documentation make sense?
 


### PR DESCRIPTION
Scope
=====

Improve the review section.


Why we got into this (5 whys)
=============================

* I was not applying all the review instructions to Trac tickets.
* I mistakenly though most of the styleguide review process applied
only to Github, and was treating Trac issues review differently.
* I though this review applied more to code and for other tasks it was
not really very important.


Changes
=======

Made some additions to the Styleguide review page.


Reviewers
========

reviewers: @hcs0 @brunogola @dumol  
