### PR TITLE
[#3870] Update paver.conf and pavement.y to do paver tasks with styleguide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,19 @@
-Chevah Project Coding Style Guide
-=================================
+Chevah Project Style Guide
+==========================
 
-This is the source for http://styleguide.chevah.com hosted via GitHub Pages.
+This repository is the source for the Chevah Styleguide at
+http://styleguide.chevah.com hosted via GitHub Pages.
 
-Pelican is used for generating static pages. Blog article generation from
+Pelican is used for generating static pages. 
 
-Pelican blog article template is hijacked to generate simple pages.
-This is done since we don't care about blog part but don't want to create
+The markup used is reStructuredText.
+
+The Pelican blog article template is used to generate simple pages.
+This is done since we don't care about the blog part but don't want to create
 'content/pages' folder in order to automatically generate all pages...
 and also have 'pages/*' URLs.
 
-See the changes using `paver run`.
+Run `paver deps` then `paver run` to build the project locally.
 
 Continuously update content with `paver dev`.
 

--- a/pavement.py
+++ b/pavement.py
@@ -18,7 +18,7 @@ from paver.easy import needs, pushd, task, consume_args
 default
 help
 
-SETUP['pypi']['index_url'] = 'http://pypi.chevah.com:10042/simple'
+SETUP['pypi']['index_url'] = 'http://pypi.chevah.com/simple'
 
 hyde_path = pave.fs.join([pave.path.build, 'bin', 'hyde'])
 python_27 = pave.fs.join([pave.path.build, 'bin', 'python'])

--- a/paver.conf
+++ b/paver.conf
@@ -1,7 +1,7 @@
 BRINK_VERSION='0.49.3'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
-PIP_INDEX='http://pypi.chevah.com:10042'
+PIP_INDEX='http://pypi.chevah.com'
 PAVER_VERSION='1.2.1'
 PIP_VERSION="1.4.1-c3"
 SETUPTOOLS_VERSION="1.4.1"

--- a/paver.conf
+++ b/paver.conf
@@ -1,7 +1,7 @@
-BRINK_VERSION='0.49.3'
+BRINK_VERSION='0.57.0'
 PYTHON_VERSION='python2.7'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'
-PAVER_VERSION='1.2.1'
-PIP_VERSION="1.4.1-c3"
+PAVER_VERSION='1.2.4'
+PIP_VERSION="1.4.1.c4"
 SETUPTOOLS_VERSION="1.4.1"


### PR DESCRIPTION
Scope
=====

Cannot do paver tasks with the styleguide repo due to what seems to be an incorrect link.


Why we got into this (5 whys)
=============================

* Doing a large documentation change so it would be useful to be able to run the changes locally.


Changes
=======

Updated paver.conf and pavement.py 
Had to do ``paver deps`` before I can do ``paver run``.  I tried this twice.  So I updated the readme...

How to try and test the changes
===============================

reviewers: @adiroiban 

I was not able to do paver run locally until I updated these two files.
Following that, do ``paver deps`` then ``paver run``.