### PR TITLE
Add information about unicode_literals and byte strings.

### DIFF
--- a/content/python.rst
+++ b/content/python.rst
@@ -106,8 +106,10 @@ NO
     other_bad = "string"
     some_bad = "string 'b' yes"
 
-* Use `from __future__ import unicode_literals` for Python3 compatibility.
-  More details:
+* As we look forward to support Python 3, we should use
+  `from __future__ import unicode_literals`, as it helps with readability,
+  instead of explicitly having to mark every text string as `u'unicode'`.
+  More details here:
   https://python-future.org/compatible_idioms.html#strings-and-bytes
 
 * All byte strings should be explicitly marked as in `b'byte string`.

--- a/content/python.rst
+++ b/content/python.rst
@@ -106,6 +106,12 @@ NO
     other_bad = "string"
     some_bad = "string 'b' yes"
 
+* Use `from __future__ import unicode_literals` for Python3 compatibility.
+  More details:
+  https://python-future.org/compatible_idioms.html#strings-and-bytes
+
+* All byte strings should be explicitly marked as in `b'byte string`.
+
 * As PEP8 recommends, don't use '\' to split long lines. Wrap long lines by
   using Python's implied line continuation inside parentheses, brackets and
   braces. More details here:


### PR DESCRIPTION
Scope
=====

Adding information regarding the use of `from __future__ import unicode_literals` and about explicitly marking all byte strings using the `b'byte string'` syntax.

How to try and test the changes
===============================

reviewers: @adiroiban @alibotean 

Please check if it makes sense.