### PR TITLE
[#3922] Add onboarding and other minor additions to Styleguide

### DIFF
--- a/content/defects-tech-debt.rst
+++ b/content/defects-tech-debt.rst
@@ -218,6 +218,7 @@ Things that can be done in this day:
 * push or send upstream your local changes to open source projects
 * fix a bug in an upstream open source project.
 
+After each day, please send email feedback to the team to talk about what you have done.
 
 References
 ==========

--- a/content/defects-tech-debt.rst
+++ b/content/defects-tech-debt.rst
@@ -218,7 +218,12 @@ Things that can be done in this day:
 * push or send upstream your local changes to open source projects
 * fix a bug in an upstream open source project.
 
-After each day, please send email feedback to the team to talk about what you have done.
+After each hacking session, please send email feedback to the team to talk
+about what you have done.
+
+If you cannot participate on the day, you can use another day to work on the
+Happy Hacking session.
+
 
 References
 ==========

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -69,10 +69,16 @@ This section is also used for other frequent questions sent to Support / Sales
 that are not otherwise covered in the main documentation.
 
 User guides can also be written to the more general audience depending on the
-content.
+content. It is a good idea to specifically list out who the audience is.
 
 If the page has a specific audience in mind, state the audience in the
 introduction of the page.
+
+
+About Sphinx
+============
+
+Sphinx is a documentation generator that uses reStructuredText as its markup language, extending and using Docutils for parsing. Both Sphinx and Docutils were created in Python to document Python, but documenting C and C++ is also supported. Sphinx supports several output formats directly, such as HTML, LaTeX, and ePub, and supports PDF output via either LaTeX or the external rst2pdf tool.
 
 
 Using reStructuredText (rst)
@@ -256,6 +262,19 @@ Further details about generating and building documentation is found in the
 chevah server repository.
 
 
+Communicating command-line syntax
+----------------------------------
+
+Use the following convention:
+
+.. sourcecode:: bash
+
+    $ client-shell webdavs://user@acme.onmicrosoft.com@acme.sharepoint.com -p 'password'
+    > connect
+
+$ means a non-root user, # is a root user and > means a client-shell command.
+
+
 Documenting the code
 ====================
 
@@ -431,3 +450,18 @@ page.
 
 Known Issues will include a reference to the internal Trac ID which provided
 further details about that issues
+
+Mock ups and Designs
+====================
+
+If a change involves a design or content addition (such as an image carousel in JS), it is a good idea to write/mock up the content first before doing any coding.  In this way, you can check to see what type of code work should be done to best communicate the content.
+
+Please go to the 'design' repository for sample images and screenshots to use and add your own samples.
+
+If raw HTML needs to be used, aim to use directives such as:
+
+.. sourcecode:: bash
+
+    :call_for_action: Ready to install SFTPPlus?
+    :call_for_action_link: /pricing/?utm_source=client&utm_campaign=clientbtn&utm_medium=btn#id1
+    :call_for_action_button: Ask for a trial

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -78,16 +78,21 @@ If the page has a specific audience in mind, state the audience in the
 introduction of the page.
 
 
-About Sphinx
-============
-
-Sphinx is a documentation generator that uses reStructuredText as its markup language, extending and using Docutils for parsing. Both Sphinx and Docutils were created in Python to document Python, but documenting C and C++ is also supported. Sphinx supports several output formats directly, such as HTML, LaTeX, and ePub, and supports PDF output via either LaTeX or the external rst2pdf tool.
-
-
 Using reStructuredText (rst)
 ============================
 
-Narrative documentation is delivered in the reStructuredText (.rst) format.  
+We use `Sphinx <http://www.sphinx-doc.org/en/stable/>`_ as a documentation
+generator that uses reStructuredText as its markup language, extending and
+using Docutils for parsing.
+
+Both Sphinx and Docutils were created in Python to document Python, but
+documenting C and C++ is also supported.
+
+Sphinx supports several output formats directly, such as HTML, LaTeX, and ePub,
+and supports PDF output via either LaTeX or the external rst2pdf tool.
+
+For us, rarrative documentation is delivered in the reStructuredText (.rst)
+format.  
 
 Further details are available in this
 `Docutils documentation page <http://docutils.sourceforge.net/rst.html>`_. 
@@ -270,12 +275,23 @@ Communicating command-line syntax
 
 Use the following convention:
 
-.. sourcecode:: bash
+.. sourcecode:: shell
 
     $ client-shell webdavs://user@acme.onmicrosoft.com@acme.sharepoint.com -p 'password'
     > connect
 
-$ means a non-root user, # is a root user and > means a client-shell command.
+
+.. sourcecode:: bash
+
+    # useradd sftpplus
+    # groupadd sftpplus
+
+
+``$`` means a non-root user. 
+
+``#`` is a root user.
+
+``>`` means a client-shell command.
 
 
 Documenting the code
@@ -454,17 +470,25 @@ page.
 Known Issues will include a reference to the internal Trac ID which provided
 further details about that issues
 
-Mock ups and Designs
-====================
+Mock ups and designs for the website
+====================================
 
-If a change involves a design or content addition (such as an image carousel in JS), it is a good idea to write/mock up the content first before doing any coding.  In this way, you can check to see what type of code work should be done to best communicate the content.
+If a change involves a design or content addition (such as an image carousel
+in JS), it is a good idea to write/mock up the content first before coding.
 
-Please go to the 'design' repository for sample images and screenshots to use and add your own samples.
+In this way, you can check to see what type of code work should be done to best
+communicate the content.
 
-If raw HTML needs to be used, aim to use directives such as:
+Please go to the 'design' repository for sample images and screenshots to use
+and add your own samples.
+
+If raw HTML needs to be used, see if custom directives can be used such as:
 
 .. sourcecode:: bash
 
     :call_for_action: Ready to install SFTPPlus?
     :call_for_action_link: /pricing/?utm_source=client&utm_campaign=clientbtn&utm_medium=btn#id1
     :call_for_action_button: Ask for a trial
+
+For documentation pages, please do not add raw HTML as the format is designed
+to be converted into multiple other formats.

--- a/content/onboarding.rst
+++ b/content/onboarding.rst
@@ -1,0 +1,162 @@
+Onboarding
+##########
+
+:menu_order: 1
+:url: /onboarding.html
+:save_as: onboarding.html
+
+This repo is used to organize tasks and track the onboarding process for new members. You can see who else is going through the onboarding process `here <https://github.com/orgs/chevah/teams/onboarding>`_.
+
+**Things to note and do:**
+
+- You can use your personal accounts.
+
+- Initially your GitHub account is only part of the onboarding team with limited access to resources.
+
+- Ask one of the system administrators to add your email to our groups / mailing lists.
+
+- During onboarding, please arrange and send a calendar invite to weekly meetings with your onboarding supervisor. 
+
+- Be connected to IRC on #chevah while you are "in the office".
+
+
+1. First stage
+--------------
+
+**Create the Github milestone**
+
+To practice your GitHub issue management skills, create your milestone as 'YOUR-NAME Onboarding' in the chevah/onboarding repository and create the initial tickets associated with your onboarding project.
+
+Below is a list of initial issues/tasks to be added in the milestone:
+
+**Review and provide feedback for chevah/styleguide**
+
+- The styleguide is at http://styleguide.chevah.com/
+
+- Comments/suggestions can be added in the ticket.
+
+When submitting repo changes based on your feedback:
+
+- Clone the repository, create a new branch and modify the file/s with your changes.
+
+- Create pull requests (PRs) with these changes. 
+
+- Use the `Github PR template <https://github.com/chevah/styleguide/blob/463556d4e9219e28fd030759ba7af9c0a3ec89e6/.github/PULL_REQUEST_TEMPLATE>`_ and @ mention the oboarding supervisor for review.
+
+**Review and provide feedback for the SFTPPlus server/client products**
+
+- Obtain the trial version of the server and client.
+
+- You can choose whichever OS to trial the product in.
+
+- Follow the installation in the documentation.
+
+- Any issues or comments can be mentioned in the Milestone tickets.
+
+
+**Review and provide feedback for the SFTPPlus.com website.**
+
+- Review the SFTPPlus.com website excluding the documentation.
+
+- Comment in the Milestone your feedback.
+
+When submitting repo changes based on your feedback:
+
+- Clone the repository chevah/sftpplus.com and create PRs to the chevah/sftpplus.com repo.
+
+- Follow the README requirements and development to run the site locally.
+
+- Use the PR template and @ mention the onboarding supervisor for review.
+
+- Please take note of the README in the repo for additional requirements.
+
+
+For any of the tasks above, feel free to check existing or previous milestones for ideas on scope and approach.
+
+
+2. Know the basic rules
+-----------------------
+
+We have basic requirements and practices when working for the Chevah project. Ask the tech lead for any questions.
+
+* Take note of the `coding conventions <http://styleguide.chevah.com>`_ applied for this project. These general coding conventions are for all 'texts' (code, documentation, etc). 
+
+* There are specific rules that apply to programming languages. Begin by reading the general `coding conventions <http://styleguide.chevah.com>`_. Then review each language specific convention as you will be writing in that language.
+
+* While you are in IRC on #chevah "in the office", set to auto-away to let others know that you are not at the computer. Set the away status to "busy" (/away busy) if you are working at something and don't want to be disturbed.
+
+* You will use your own hardware for work tasks. To compensate for this usage of your hardware we will cover hardware expenses for your home computer. If you need a hardware component or peripheral that will help your work related tasks, ask and we can cover those expenses. Ask tech lead for details.
+
+* Each task that you are working on should have a ticket in Trac/Github. If there is no ticket, create one and start the `Ticket Work Flow <http://styleguide.chevah.com/tickets.html>`_. 
+
+* While some tasks are on Github, there is a Trac/Github integration. See `Overview of the GitHub and Trac integration <http://styleguide.chevah.com/review.html#overview-of-the-github-and-trac-integration>`_.
+
+* Tickets corresponding to you that you are currently working should have the 'owner' value set to your Trac username.
+
+* If a task requires more than two days of work, split the task in multiple ticket each requiring no more than 2 days to complete.
+
+* Please go to the Trac WikiStart page which will contain further links to more details and specific documentation for certain parts of the Chevah project.
+
+* From time to time, check the Trac timeline to stay up to date with latest changes in the project.
+
+* When starting a support ticket, request the OS version architecture used and version of the SFTPPlus products. Further details in Trac.
+
+* Before a Pull Request is closed, it must be reviewed by at least one other team member. Further info of the Review process `here <http://styleguide.chevah.com/review.html>`_.
+
+* Leave days can be requested at any time. Check the dedicated page in Trac.
+
+* Add your preferred email address in Trac ( Preferences -> General ) to enable email notifications.
+
+* Update your GitHub account to display your full name, and an avatar/picture that is not the default image to help differentiate activity.
+
+* Leave temporary team messages by setting the topic of #chevah IRC channel.
+
+
+3. Get all your accounts after the initial stage
+------------------------------------------------
+
+Once the initial onboarding state is over, you will get full access to the project's resources.
+
+The initial stage is over when all the Onboarding tickets from the milestone dedicated to your onboarding process are finalized.
+
+We are far from single-sign-on and while working on this project you will have many different accounts.
+
+For GitHub you can create a new account or use your current account and ask to be part of our GitHub organisations (Chevah and ProAtria) and our core team. Ensure that in git-config, your user.email is the Pro:Atria email when working in the Chevah project repositories.
+
+We use Skype for phone calls. Use the dedicated ProAtria Skype account as the official tools to collaborate with the team and to make phone calls.
+
+**Ask our system administrators for all of the followings:**
+
+* A project-related email account on Google - enable 2-step auth.
+
+* Update the email account with the standard signature template from the private wiki for all support related emails.
+
+* System administrators will require a chevah.com account as alerts are delivered through the management server.
+
+* Request for VPN certificates to connect to internal servers/services.
+
+* You will need a Trac account setup. Trac tickets are used for managing work items since there is no support with the web-based GitHub issue/task/defect management. Trac also contains wiki pages to other documentation.  Get to know the team by checking the dedicated page in our private wiki.
+
+
+4. Exploring SFTPPlus for the first time
+----------------------------------------
+
+When testing out the software, please take a look at the contents of these folders as it may contain useful files for exploring various features of SFTPPlus.  
+
+Test_Data
+^^^^^^^^^
+
+In the server repository is a folder called test_data which contains configuration file samples, public/private key samples, various certificates in a number of formats, a test LDAP server to support manual tests ( run as $ ./build* test_data/ldap/server.py), HTTP proxy and simpel HTTP server, and sample execute scripts for post transfer execution.
+
+Users_Files
+^^^^^^^^^^^
+
+In the build folder are example folders of a test user which can be used to help test various features of SFTPPlus.
+
+Below is an example of using users_files / the test user to access the HTTPS feature:
+
+1. Navigate to the server folder
+2. ./paver.sh run and log in to https://localhost:10020
+3. Under Status in the Local Manager edit the https status configuration and add app-uuid. This is so that application accounts are enabled for this service.
+4. Save the configuration and selected Start
+5. Go to https://localhost:10443 and log in using the test data credentials. If you go to test-server.ini in the test-data folder you can see the credentials to log in as the test user.  After authenticating, you should see the test folders and files.

--- a/content/tickets.rst
+++ b/content/tickets.rst
@@ -33,6 +33,8 @@ It is ok to attach screenshots as a last resort but always try to describe the i
 When you start working at a task, you can optionally accept that task and the task will be considered 'in work'.
 At any given time, a team member should not have more than 3 'in work' tickets.
 
+When creating a ticket you can set yourself as the owner if you are implementing the task.
+
 
 Work priority
 =============
@@ -202,3 +204,4 @@ See https://trac.chevah.com/ticket/3391 for an example of a Story Ticket.
 
 Use this to list out smaller tasks associated with a larger task, such as the "Add WebDAV client" ticket.
 
+This may be a good ticket type to use if you are carrying out a high level task and need to keep track of notes on Trac...

--- a/content/tickets.rst
+++ b/content/tickets.rst
@@ -26,7 +26,7 @@ When we eventually migrate away from Trac, we may find it difficult to migrate t
 
 * For text files, try to use the descriptions or create a dedicate wiki page.
 * For logs, errors, long code samples from test reviews, use gist.github.com.  
-* For pictures and other non/text data, you can attach these.
+* For pictures and other non/text data, you can attach these as a last resort.
 
 It is ok to attach screenshots as a last resort but always try to describe the issue in a way where the screenshot is not really required and where you can report a text log or text error.
 
@@ -141,7 +141,9 @@ Below is a list of used tags:
 Ticket components
 -----------------
 
-Components and their explanations:
+This area is being revisited. 
+
+But the components are currently:
 
  * client-commons
  * client-ftp
@@ -152,27 +154,27 @@ Components and their explanations:
  * infrastructure
  * libs
  * manager
- * pr (I think this is website/marketing related?)
+ * pr (website/marketing related)
  * server-commons
  * server-ftp
  * server-http
  * server-ssh
- * support (also includes documentation, anything that involves information to the customer)
+ * support (also includes documentation)
  * webadmin
 
 
 Milestone planning
 ==================
 
-At the start of each cycle, we create a milestone that represents our focus for the next month or week. We add new tickets to the new milestone or move tickets from 'Horse's Easter' milestone.
+At the start of each cycle, we create a milestone that represents our focus for the next month or week. We add new tickets to the new milestone. 
+
+Milestones can be next-release, followed by Y-Near-Future, Z-Long-Term.
+
+Milestones associated with a release are also included.
 
 Until the all tickets from the milestones/sprint are done, we should not work on any other task/ticket. If we start working on something, that something should be added to the current milestone.
 
 If new tasks/tickets are required, they are discussed with the team and if they are important they are added to the current milestone. If the milestone is already full, adding a new ticket might imply removing an already planed ticket.
-
-Usually, milestones are set to next-release, followed by Y-Near-Future, Z-Long-Term.
-
-Milestones associated with a release are also included.
 
 
 How not to be turned down by the big amount of opened bugs ?

--- a/content/tickets.rst
+++ b/content/tickets.rst
@@ -24,9 +24,9 @@ The ticket workflow is described in a computer friendly manner here: https://gis
 Try not to upload attachments to tickets.
 When we eventually migrate away from Trac, we may find it difficult to migrate the attachments.
 
-* For text files, try to use the descriptions... or create a dedicate wiki page.
-* For logs, errors... etc use gist.github.com .
-* For pictures and other non/text data... I don't know, just attach it.
+* For text files, try to use the descriptions or create a dedicate wiki page.
+* For logs, errors, long code samples from test reviews, use gist.github.com.  
+* For pictures and other non/text data, you can attach these.
 
 It is ok to attach screenshots as a last resort but always try to describe the issue in a way where the screenshot is not really required and where you can report a text log or text error.
 
@@ -136,14 +136,41 @@ Below is a list of used tags:
   - These are tasks that don’t require knowledge of the product or operating system 'know-how' in advance.
 
 
+Ticket components
+-----------------
+
+Components and their explanations:
+
+ * client-commons
+ * client-ftp
+ * client-http
+ * client-ssh
+ * component not set
+ * gateway
+ * infrastructure
+ * libs
+ * manager
+ * pr (I think this is website/marketing related?)
+ * server-commons
+ * server-ftp
+ * server-http
+ * server-ssh
+ * support (also includes documentation, anything that involves information to the customer)
+ * webadmin
+
+
 Milestone planning
 ==================
 
-At the start of each cycle, we create a milestone or a sprint that represents our focus for the next month or week. We add new tickets to the new milestone or move tickets from 'Horse's Easter' milestone.
+At the start of each cycle, we create a milestone that represents our focus for the next month or week. We add new tickets to the new milestone or move tickets from 'Horse's Easter' milestone.
 
 Until the all tickets from the milestones/sprint are done, we should not work on any other task/ticket. If we start working on something, that something should be added to the current milestone.
 
 If new tasks/tickets are required, they are discussed with the team and if they are important they are added to the current milestone. If the milestone is already full, adding a new ticket might imply removing an already planed ticket.
+
+Usually, milestones are set to next-release, followed by Y-Near-Future, Z-Long-Term.
+
+Milestones associated with a release are also included.
 
 
 How not to be turned down by the big amount of opened bugs ?
@@ -166,3 +193,12 @@ The 'Horse easter' milestone is used for all long term tickets. Many of the tick
 You don't need to bother about these tickets and most of the time they can be ignored.
 
 Same for 'Near future' milestones.
+
+
+Story Tickets
+-------------
+
+See https://trac.chevah.com/ticket/3391 for an example of a Story Ticket.
+
+Use this to list out smaller tasks associated with a larger task, such as the "Add WebDAV client" ticket.
+


### PR DESCRIPTION
Scope
=====

- Move onboarding to Styleguide
- I kept a running diary of notes in the ticket, which ended up being condensed or I was repeating things already in the Styleguide so I left it out.


Why we got into this (5 whys)
=============================

Keep Styleguide up to date


Changes
=======

reviewers: @adiroiban 

Can you comment more on:
Story tickets and ticket components.

With onboarding I just copied over what's on Github and if there is feedback about onboarding process from someone omboarding they can make the changes.