### PR TITLE
[#4012] Add about info in documentation in styleguide

### DIFF
--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -392,6 +392,9 @@ For example, instead of 'user', add a real name such as 'alice' or 'bob':
 Ensure to add examples for the text file configuration as first priority,
 followed by steps in the Local Manager GUI.
 
+The configuration / log examples are added *after* a narrative description of
+the example.
+
 
 Updating the documentation
 ==========================

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -62,12 +62,12 @@ semicolons, rather than after the Nth column.
     long lines.
 
 
-About the Documentation Sections
-================================
+Structure of the Documentation
+==============================
 
 **Introduction**
 
-High level introduction to the software.
+High level introduction to the software and general concepts about the product.
 
 
 **Installation and Upgrade Instructions**
@@ -75,18 +75,12 @@ High level introduction to the software.
 System requirements, installation, installation validation/procedures, upgrade
 procedures, uninstallation instructions.
 
-
-**Getting Started with SFTPPlus**
-
-Prerequisite to this page is the installation section.
-
-Contains information about the initial, basic configurations that come with the
-installation package and first account configurations.
+This information is for the sysadmins.
 
 
 **Configuration Instructions**
 
-Should contain information to the general configuration principle and
+Contains information to the general configuration principle and
 references for each configuration option.
 
 This section focuses only on the **individual configuration options**.
@@ -100,7 +94,7 @@ configuration options available for this service.
 
 **Operation (under 'Usage Instructions')**
 
-Should only contain general principles of operation.
+Contains general principles of operation.
 
 The section can go into further detail about a particular feature or service
 beyond the configuration file and configuration file options.
@@ -112,7 +106,8 @@ are available with this service, examples of usage and more.
 **User's Guides**
 
 Pages in the User's Guides are used to describe how a task can be performed by
-applying various configuration options.
+applying various configuration options. Examples need to reflect real world
+cases.
 
 This section is also used for other frequent questions sent to Support / Sales.
 

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -118,8 +118,7 @@ Before adding to the Users Guide, check to make sure that the information is
 better suited elsewhere - such as the Operations or Configuration sections.
 
 
-Miscellaneous Topics
---------------------
+**Miscellaneous Topics**
 
 These are pages that do not otherwise fall under the other main sections.
 

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -62,20 +62,71 @@ semicolons, rather than after the Nth column.
     long lines.
 
 
-Writing User's Guides
-=====================
+About the Documentation Sections
+================================
+
+**Introduction**
+
+High level introduction to the software.
+
+
+**Installation and Upgrade Instructions**
+
+System requirements, installation, installation validation/procedures, upgrade
+procedures, uninstallation instructions.
+
+
+**Getting Started with SFTPPlus**
+
+Prerequisite to this page is the installation section.
+
+Contains information about the initial, basic configurations that come with the
+installation package and first account configurations.
+
+
+**Configuration Instructions**
+
+Should contain information to the general configuration principle and
+references for each configuration option.
+
+This section focuses only on the **individual configuration options**.
+
+Samples and guides in this section should be aimed at the Local Manager GUI
+and the text file configuration.
+
+For example, the HTTP/HTTPS configuration page is only restricted to the
+configuration options available for this service.
+
+
+**Operation (under 'Usage Instructions')**
+
+Should only contain general principles of operation.
+
+The section can go into further detail about a particular feature or service
+beyond the configuration file and configuration file options.
+
+For example, the HTTP/HTTPS operations page goes into detail about what actions
+are available with this service, examples of usage and more.
+
+
+**User's Guides**
 
 Pages in the User's Guides are used to describe how a task can be performed by
 applying various configuration options.
 
-This section is also used for other frequent questions sent to Support / Sales
-that are not otherwise covered in the main documentation.
+This section is also used for other frequent questions sent to Support / Sales.
 
-User guides can also be written to the more general audience depending on the
-content. It is a good idea to specifically list out who the audience is.
+Can be written to the more general audience. 
+It is a good idea to list out who the audience is.
 
-If the page has a specific audience in mind, state the audience in the
-introduction of the page.
+Before adding to the Users Guide, check to make sure that the information is
+better suited elsewhere - such as the Operations or Configuration sections.
+
+
+Miscellaneous Topics
+--------------------
+
+These are pages that do not otherwise fall under the other main sections.
 
 
 Using reStructuredText (rst)
@@ -91,7 +142,11 @@ documenting C and C++ is also supported.
 Sphinx supports several output formats directly, such as HTML, LaTeX, and ePub,
 and supports PDF output via either LaTeX or the external rst2pdf tool.
 
-For us, rarrative documentation is delivered in the reStructuredText (.rst)
+Due to the ability to output to several formats, keep in mind how the output
+will look like. For example, raw HTML is discouraged as this will affect the
+look of a PDF output.
+
+For us, narrative documentation is delivered in the reStructuredText (.rst)
 format.  
 
 Further details are available in this
@@ -194,6 +249,10 @@ When linking to external web links:
 
     `Bug Writing Guidelines <http://developer.mozilla.org/en/docs/Bug_writing_guidelines>`_
 
+When linking to other resources, aim to make documentation be as cursive as
+possible - meaning that users should not have to break mid-guide and search for
+other information.
+
 
 Breaking up long lines of logs
 ------------------------------
@@ -241,6 +300,9 @@ For example, instead of 'user', add a real name such as 'alice' or 'bob':
     description = Staff SFTPPlus application account for Mark
     home_folder_path = /PATH/TO/MARK/HOME
     password = PASSWORD
+
+Since many customers are using the text file configuration, it is a good idea
+to include this along with steps in the Local Manager GUI.
 
 
 Updating the documentation

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -72,8 +72,8 @@ High level introduction to the software and general concepts about the product.
 
 Lists supported protocols.
 
-Includes a small section on product development section - not to be confused
-with roadmap or the more developed Product section.
+Includes a small section on product development section
+- not to be confused with roadmap or the more developed Product section.
 
 
 Installation and Upgrade Instructions
@@ -111,15 +111,25 @@ Configuration details are in the format of:
     
      HEADING: Name of the configuration as it appears in the text file
         configuration
+
     :Default value: Specifies default value - can be Yes, No, Disabled, etc
+
     :Optional: ie Yes / No
+
     :From version: Specifies the version from which this is available
+
     :Values: * Specify a list of values available in list format.
-        The values could include; whether or not a file path is accepted and
-        what the file path should lead to, whether or not this can be
-        Inherited, what placeholders are involved, type of value accepted 
-        (ie if the value is in seconds) etc.
+
+        The values could include; 
+        whether or not a file path is accepted,
+        what the file path should lead to,
+        whether or not this can be inherited,
+        what placeholders are involved,
+        type of value accepted (ie if the value is in seconds) etc,
+        and more.
+
     :Description:
+
         Describes the values and options only.
 
         Examples and adnotation classes can be added as long as it relates to
@@ -132,24 +142,29 @@ Configuration details are in the format of:
         additional usage tips.
 
         Everything that is relevant to this configuration should be added in
-        the description area so that the user can read without having to 
-        reference other parts of the page or documentation.
+        the description area
+        so that the user can read without having to reference other parts of the page or documentation.
 
         Generally, a customer will enquire about a specific value or
-        configuration in SFTPPlus therefore all details relevant to the values
-        are included in the description.
+        configuration in SFTPPlus
+        therefore all details relevant to the values are included in the description.
+        
 
-The sections and configuration options can be grouped into whether or not it is
-applicable to application accounts only, operating system accounts only, to
-certain platforms only, and so on. 
+The sections and configuration options can be grouped into;
+whether or not it is applicable to application accounts only,
+operating system accounts only,
+to certain platforms only,
+and so on. 
+
 In this way, an administrator only needs to use the subheading as the reference
 point before deciding to read further into a section.
 
-Content can also be grouped according to what 'action' that is involved - ie
-'Adding X', 'Activating Y', 'Extracting Z'. 
+Content can also be grouped according to what 'action' that is involved
+- ie 'Adding X', 'Activating Y', 'Extracting Z'. 
 
 When recommending that a user use a certain format, also add an example of this
-format. For example, if recommending a UPN format be used, add a UPN example.
+format.
+For example, if recommending a UPN format be used, add a UPN example.
 
 
 Operation (called 'Usage Instructions')
@@ -165,16 +180,16 @@ antivirus interfaces with SFTPPlus.
 Describes how SFTPPlus operates in relation to a specific area -
 authentication, filesystem access, client-shell command line usage etc.
 
-There is environment-specific information - for example, how specific operating
-systems interface with parts of SFTPPlus.
+There is environment-specific information
+- for example, how specific operating systems interface with parts of SFTPPlus.
 
 Further describes specific operations and how the software works due to a
-specific scenario (scenarios can be included), network (ie what happens when
-multiple servers are involved).
+specific scenario (scenarios can be included)
+and network (ie what happens when multiple servers are involved).
 
-Covers management related topics related to operating SFTPPlus - such as key
-and certificate management, debugging/testing the software, and other topics
-relevant to system and network administrators.
+Covers management related topics related to operating SFTPPlus
+- such as key and certificate management, debugging/testing the software,
+and other topics relevant to system and network administrators.
 
 
 User's Guides
@@ -190,7 +205,8 @@ Can be written to the more general audience.
 It is a good idea to list out who the audience is.
 
 Before adding to the Users Guide, check to make sure that the information is
-better suited elsewhere - such as the Operations or Configuration sections.
+better suited elsewhere
+- such as the Operations or Configuration sections.
 
 
 Miscellaneous Topics
@@ -208,14 +224,15 @@ We use `Sphinx <http://www.sphinx-doc.org/en/stable/>`_ as a documentation
 generator that uses reStructuredText as its markup language, extending and
 using Docutils for parsing.
 
-Both Sphinx and Docutils were created in Python to document Python, but
-documenting C and C++ is also supported.
+Both Sphinx and Docutils were created in Python to document Python,
+but documenting C and C++ is also supported.
 
 Sphinx supports several output formats directly, such as HTML, LaTeX, and ePub,
 and supports PDF output via either LaTeX or the external rst2pdf tool.
 
-Spinx can output to several formats. Due to this raw HTML in documentation is
-discouraged as this will affect the look of a PDF output.
+Spinx can output to several formats.
+Raw HTML in documentation is discouraged as this will affect the look of a PDF
+output.
 
 For us, narrative documentation is delivered in the reStructuredText (.rst)
 format.  
@@ -321,8 +338,8 @@ When linking to external web links:
     `Bug Writing Guidelines <http://developer.mozilla.org/en/docs/Bug_writing_guidelines>`_
 
 When linking to other resources, aim to make documentation be as cursive as
-possible - meaning that users should not have to break mid-guide and search for
-other information.
+possible.
+This means that users should not have to break mid-guide to search for other information.
 
 
 Breaking up long lines of logs
@@ -592,8 +609,8 @@ There is a page on the documentation where Known Issues and the ID are listed
 publicly
 `here <https://www.sftpplus.com/documentation/sftpplus/latest/known-issues.html>`_.
 
-The page is useful for handling Support queries. For example, if a
-customer finds a problem with the software, check that the problem exists in
+The page is useful for handling Support queries.
+For example, if a customer finds a problem with the software, check that the problem exists in
 the Known Issues list first.
 
 If there is an existing issues, then the customer can continue using the
@@ -602,6 +619,7 @@ page.
 
 Known Issues will include a reference to the internal Trac ID which provided
 further details about that issues
+
 
 Mock ups and designs for the website
 ====================================

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -93,7 +93,7 @@ Contains information to the general configuration principle and
 references for each configuration option.
 
 Other general information can also be added (ie general information about a
-supported protocol) to help aid in understanding its configuration in SFTPPLus.
+supported protocol) to help aid in understanding its configuration in SFTPPlus.
 Further details can be referenced for later reading.
 
 Samples and guides are aimed at configuring the Local Manager GUI and the text

--- a/content/documentation.rst
+++ b/content/documentation.rst
@@ -65,49 +65,124 @@ semicolons, rather than after the Nth column.
 Structure of the Documentation
 ==============================
 
-**Introduction**
+Introduction
+------------
 
 High level introduction to the software and general concepts about the product.
 
+Lists supported protocols.
 
-**Installation and Upgrade Instructions**
-
-System requirements, installation, installation validation/procedures, upgrade
-procedures, uninstallation instructions.
-
-This information is for the sysadmins.
+Includes a small section on product development section - not to be confused
+with roadmap or the more developed Product section.
 
 
-**Configuration Instructions**
+Installation and Upgrade Instructions
+-------------------------------------
+
+System requirements, installation, installation validation and troubleshooting,
+upgrade procedures, and uninstallation instructions.
+
+These instructions are aimed at system administrators and written with a level
+of assumed knowledge in mind.
+
+
+Configuration Instructions
+--------------------------
 
 Contains information to the general configuration principle and
 references for each configuration option.
 
-This section focuses only on the **individual configuration options**.
+Other general information can also be added (ie general information about a
+supported protocol) to help aid in understanding its configuration in SFTPPLus.
+Further details can be referenced for later reading.
 
-Samples and guides in this section should be aimed at the Local Manager GUI
-and the text file configuration.
+Samples and guides are aimed at configuring the Local Manager GUI and the text
+configuration file.
 
-For example, the HTTP/HTTPS configuration page is only restricted to the
-configuration options available for this service.
+Samples reflect real world use cases and not be abstract examples.
+
+When adding configuration details, add a heading introducing what the options
+are relevant to.
+Focuses only on the **individual configuration options** specific
+to SFTPPlus.
+Configuration details are in the format of:
+
+.. sourcecode:: rst
+    
+     HEADING: Name of the configuration as it appears in the text file
+        configuration
+    :Default value: Specifies default value - can be Yes, No, Disabled, etc
+    :Optional: ie Yes / No
+    :From version: Specifies the version from which this is available
+    :Values: * Specify a list of values available in list format.
+        The values could include; whether or not a file path is accepted and
+        what the file path should lead to, whether or not this can be
+        Inherited, what placeholders are involved, type of value accepted 
+        (ie if the value is in seconds) etc.
+    :Description:
+        Describes the values and options only.
+
+        Examples and adnotation classes can be added as long as it relates to
+        the configuration.
+
+        Describes what happens to the configuration if a certain value is used
+        (and not used).
+
+        Add what the user needs to do to configure the values properly and
+        additional usage tips.
+
+        Everything that is relevant to this configuration should be added in
+        the description area so that the user can read without having to 
+        reference other parts of the page or documentation.
+
+        Generally, a customer will enquire about a specific value or
+        configuration in SFTPPlus therefore all details relevant to the values
+        are included in the description.
+
+The sections and configuration options can be grouped into whether or not it is
+applicable to application accounts only, operating system accounts only, to
+certain platforms only, and so on. 
+In this way, an administrator only needs to use the subheading as the reference
+point before deciding to read further into a section.
+
+Content can also be grouped according to what 'action' that is involved - ie
+'Adding X', 'Activating Y', 'Extracting Z'. 
+
+When recommending that a user use a certain format, also add an example of this
+format. For example, if recommending a UPN format be used, add a UPN example.
 
 
-**Operation (under 'Usage Instructions')**
+Operation (called 'Usage Instructions')
+---------------------------------------
 
-Contains general principles of operation.
-
-The section can go into further detail about a particular feature or service
-beyond the configuration file and configuration file options.
-
+Contains general principles of operating SFTPPlus correctly.
 For example, the HTTP/HTTPS operations page goes into detail about what actions
 are available with this service, examples of usage and more.
 
+Includes other features or services that interface with SFTPPlus such as how
+antivirus interfaces with SFTPPlus.
 
-**User's Guides**
+Describes how SFTPPlus operates in relation to a specific area -
+authentication, filesystem access, client-shell command line usage etc.
+
+There is environment-specific information - for example, how specific operating
+systems interface with parts of SFTPPlus.
+
+Further describes specific operations and how the software works due to a
+specific scenario (scenarios can be included), network (ie what happens when
+multiple servers are involved).
+
+Covers management related topics related to operating SFTPPlus - such as key
+and certificate management, debugging/testing the software, and other topics
+relevant to system and network administrators.
+
+
+User's Guides
+-------------
 
 Pages in the User's Guides are used to describe how a task can be performed by
-applying various configuration options. Examples need to reflect real world
-cases.
+applying various configuration options.
+Examples need to reflect real world cases.
 
 This section is also used for other frequent questions sent to Support / Sales.
 
@@ -118,9 +193,12 @@ Before adding to the Users Guide, check to make sure that the information is
 better suited elsewhere - such as the Operations or Configuration sections.
 
 
-**Miscellaneous Topics**
+Miscellaneous Topics
+--------------------
 
-These are pages that do not otherwise fall under the other main sections.
+These are pages that do not otherwise fall under the other main sections
+but need to be in the documentation as it supports customer's operation, usage
+and understanding of SFTPPlus.
 
 
 Using reStructuredText (rst)
@@ -136,9 +214,8 @@ documenting C and C++ is also supported.
 Sphinx supports several output formats directly, such as HTML, LaTeX, and ePub,
 and supports PDF output via either LaTeX or the external rst2pdf tool.
 
-Due to the ability to output to several formats, keep in mind how the output
-will look like. For example, raw HTML is discouraged as this will affect the
-look of a PDF output.
+Spinx can output to several formats. Due to this raw HTML in documentation is
+discouraged as this will affect the look of a PDF output.
 
 For us, narrative documentation is delivered in the reStructuredText (.rst)
 format.  
@@ -295,8 +372,8 @@ For example, instead of 'user', add a real name such as 'alice' or 'bob':
     home_folder_path = /PATH/TO/MARK/HOME
     password = PASSWORD
 
-Since many customers are using the text file configuration, it is a good idea
-to include this along with steps in the Local Manager GUI.
+Ensure to add examples for the text file configuration as first priority,
+followed by steps in the Local Manager GUI.
 
 
 Updating the documentation

--- a/content/onboarding.rst
+++ b/content/onboarding.rst
@@ -5,7 +5,7 @@ Onboarding
 :url: /onboarding.html
 :save_as: onboarding.html
 
-This repo is used to organize tasks and track the onboarding process for new members. You can see who else is going through the onboarding process `here <https://github.com/orgs/chevah/teams/onboarding>`_.
+This repo is used to organize tasks and track the onboarding process for new members. You can see who else is going through the `onboarding process <https://github.com/orgs/chevah/teams/onboarding>`_.
 
 **Things to note and do:**
 
@@ -101,7 +101,7 @@ We have basic requirements and practices when working for the Chevah project. As
 
 * When starting a support ticket, request the OS version architecture used and version of the SFTPPlus products. Further details in Trac.
 
-* Before a Pull Request is closed, it must be reviewed by at least one other team member. Further info of the Review process `here <http://styleguide.chevah.com/review.html>`_.
+* Before a Pull Request is closed, it must be reviewed by at least one other team member. Further info of the `Review process <http://styleguide.chevah.com/review.html>`_.
 
 * Leave days can be requested at any time. Check the dedicated page in Trac.
 

--- a/content/onboarding.rst
+++ b/content/onboarding.rst
@@ -5,7 +5,8 @@ Onboarding
 :url: /onboarding.html
 :save_as: onboarding.html
 
-This repo is used to organize tasks and track the onboarding process for new members. You can see who else is going through the `onboarding process <https://github.com/orgs/chevah/teams/onboarding>`_.
+This repo is used to organize tasks and track the onboarding process for new members.
+You can see past/active tasks in the `onboarding repo <hhttps://github.com/chevah/onboarding/>`_.
 
 **Things to note and do:**
 

--- a/content/onboarding.rst
+++ b/content/onboarding.rst
@@ -5,7 +5,7 @@ Onboarding
 :url: /onboarding.html
 :save_as: onboarding.html
 
-This repo is used to organize tasks and track the onboarding process for new members.
+This page is used to organize tasks and track the onboarding process for new members.
 You can see past/active tasks in the `onboarding repo <hhttps://github.com/chevah/onboarding/>`_.
 
 **Things to note and do:**


### PR DESCRIPTION
Scope
=====

Give an outline of the differences between the documentation pages

Why we got into this (5 whys)
=============================

* Provides more of a structure of what goes into where
* There has been some confusion as to what should be in configuration vs operation


Changes
=======

Add about info in the documentation section.

I looked at previous comments of a couple of PRs to get some more info.


How to try and test the changes
===============================

reviewers: @alibotean @lgheorghiu  
Just thought to make a new PR
in case there are additions you want to make


_On the other hand, we may also want to look at what improvements can be made in the structure of the documentation?_