### PR TITLE
Update the release manager notes in Styleguide 

### DIFF
--- a/content/css.rst
+++ b/content/css.rst
@@ -11,7 +11,7 @@ The CSS Coding conventions are inspired by `Stoyan Stefanov's CSS Coding
 Conventions
 <http://www.phpied.com/css-coding-conventions>`_
 
-Many of them are automatically checked using pocket-lint which is now
+Many of them are automatically checked using scame which is now
 included in the CSS Coding Convention Checker.
 Please report any problems that you have with running ``paver lint`` or
 if some errors are not identified by ``paver lint``

--- a/content/defects-tech-debt.rst
+++ b/content/defects-tech-debt.rst
@@ -190,6 +190,16 @@ to go look for the details of the ticket or just ignore it, as it is not related
 to what you are doing now.
 
 
+When you find a bug 
+===================
+
+* Detail steps in ticket
+* Create a new branch with the config used already pushed in test-server.ini 
+* Add link to the branch in the ticket
+
+Make note of the commit SHA of the master branch also.
+
+
 Happy Hacking Day
 =================
 

--- a/content/defects-tech-debt.rst
+++ b/content/defects-tech-debt.rst
@@ -66,6 +66,22 @@ under the pressure of a release blocker, or when having a customer complaining
 about bad behaviour.
 
 
+Reporting a bug 
+===============
+
+Each bug should be reported in a separate ticket.
+The report should contain detailed steps for reproducing the bug, the product
+version in which this bug was observed, details of the customer and
+email/ticket communications when this bug was reported.
+For bugs which are not yet released, try to reproduce them on master and make a
+note of the master version (the commit SHA).
+
+You can create a branch for the ticket which will contain the .ini
+configuration used to reproduce the defect.
+
+Publish the branch and link to it in the ticket report.
+
+
 Technical Debt
 ==============
 
@@ -188,16 +204,6 @@ The comment should be descriptive enough so that when you are
 reading the code while working on your task it will help you decide whether
 to go look for the details of the ticket or just ignore it, as it is not related
 to what you are doing now.
-
-
-When you find a bug 
-===================
-
-* Detail steps in ticket
-* Create a new branch with the config used already pushed in test-server.ini 
-* Add link to the branch in the ticket
-
-Make note of the commit SHA of the master branch also.
 
 
 Happy Hacking Day

--- a/content/index.rst
+++ b/content/index.rst
@@ -30,10 +30,10 @@ If you have any comment or suggestions, please get in touch with us.
 You can do that over email, or adding an issue or pull request on
 `Github`_.
 
-We try to automatically check software development rules using `pocket-lint`_.
+We try to automatically check software development rules using `scame`_.
 
 This is a collection of programming craftsmanship recommendations and ideas.
 Please let us know if we fail to properly cite the source.
 
-.. _pocket-lint: https://launchpad.net/pocket-lint/
+.. _scame: https://github.com/chevah/scame
 .. _Github: https://github.com/chevah/styleguide

--- a/content/python.rst
+++ b/content/python.rst
@@ -16,7 +16,7 @@ General
 
     import this
 
-* For python, we have pocket-lint that checks for PEP8 and some other things.
+* For python, we have scame that checks for PEP8 and some other things.
 
 * `Python PEP 8 <http://www.python.org/dev/peps/pep-0008/>`_
   Style guide for Python code.

--- a/content/release.rst
+++ b/content/release.rst
@@ -32,9 +32,9 @@ All the related custom bits in the release notes are to be imported into the rel
 from the main branch though.
 
 TODO: see what to do with customers using releases from staging... maybe
-make a production release without a full Q&A review.
+make a production release without a full QA review.
 Such a release can have a normal version... and if changes are made
-during the Q&A review a new patch version is released.
+during the QA review a new patch version is released.
 
 
 Release Planning
@@ -43,13 +43,11 @@ Release Planning
 Tickets marked for the 'next-release' milestone are technically to be
 covered for the next release but in most situations these will fall beyond
 the next release.
-Tickets that must be in the 'next-release' is set with the high priority tag.
+Tickets that must be in the 'next-release' are set with priority 'High'.
 
 The general timeframe between each release is 30 to 45 days.
-However, bigfixes are worked on and released as soon as it is feasible by the
+However, bugfixes are worked on and released as soon as it is feasible by the
 development team.
-
-We are still currently working on making the release planning process better.
 
 
 Release Review Process
@@ -516,7 +514,8 @@ any time.
 Especially if a security bugfix is found, we will make a new release as soon
 as the bug is fixed.
 
-Releases may include bugfixes or product features from customers.
+Releases may include fixes for defects observed by customers or new product
+features requested by customers.
 In this case it is customary to let a customer know directly that the release
 is now available.
 It should be noted to customers that they will still need to take the

--- a/content/release.rst
+++ b/content/release.rst
@@ -37,6 +37,21 @@ Such a release can have a normal version... and if changes are made
 during the Q&A review a new patch version is released.
 
 
+Release Planning
+================
+
+Tickets marked for the 'next-release' milestone are technically to be
+covered for the next release but in most situations these will fall beyond
+the next release.
+Tickets that must be in the 'next-release' is set with the high priority tag.
+
+The general timeframe between each release is 30 to 45 days.
+However, bigfixes are worked on and released as soon as it is feasible by the
+development team.
+
+We are still currently working on making the release planning process better.
+
+
 Release Review Process
 ======================
 
@@ -74,6 +89,22 @@ Some functions of the **release manager** are:
 * Creating high priority tickets in case the tests are failing on master.
 * Coordinating story tickets for the milestone.
 
+
+Release Manager should look into obtaining access to the following:
+
+* Write access to sftpplus.com production (from infrastructure team) to
+  the news release to the website.
+* Ability to stage a release branch to staging server then to production
+  server.
+* Access to Mailchimp to send the release newsletter.
+* Access to the Support helpdesk or emails to know which customers should be
+  contacted directly if the release is awaiting upon them.
+
+
+When the release is out, the Release Manager organizes the team release
+meeting (times and dates), initiates the call and holds the meeting including
+a distributed agenda.
+A template of the release meeting, including past notes is `located here <https://drive.google.com/drive/folders/0B91muor_IWXBaHp1eExRbGcyZ28?usp=sharing>`_
 
 The Release Branch
 ==================
@@ -485,10 +516,8 @@ any time.
 Especially if a security bugfix is found, we will make a new release as soon
 as the bug is fixed.
 
-**Other questions to ask:**
-
-* If a customer-requested feature is added or if a bug fix is made, who
-  should be contacted to notify them of the new release?
-
-* Are there further updates for non-Documentation related content, like the
-  website or newsletter?
+Releases may include bugfixes or product features from customers.
+In this case it is customary to let a customer know directly that the release
+is now available.
+It should be noted to customers that they will still need to take the
+necessary steps to test the new release in their own environments.


### PR DESCRIPTION
Scope
=====

Add notes from the release manager process


Why we got into this (5 whys)
=============================

We want to be able to hand over release manager duties to other people in the team.

Changes
=======

- Added new notes from release manager feedback
- Change pocket-lint to scame

How to try and test the changes
===============================

reviewers: @adiroiban @lgheorghiu 

@adiroiban if there is anything else to add.

@lgheorghiu if the info makes sense to you and/or there is something that you need to be clearer please send through.